### PR TITLE
Add default timestamps for MySQL 5 compatibility

### DIFF
--- a/install.php
+++ b/install.php
@@ -233,9 +233,9 @@ if ($_POST["action"] == "install"){
 				" . $db->quoteIdentifier('condition') .
 				" varchar(32) default '==',
 				" . $db->quoteIdentifier('value') . " varchar( 255 ) default '',
-				" . $db->quoteIdentifier('modified') . " timestamp ,
-				" . $db->quoteIdentifier('time') . " timestamp ,
-				" . $db->quoteIdentifier('expire_time') . " timestamp ,
+				" . $db->quoteIdentifier('modified') . " timestamp DEFAULT CURRENT_TIMESTAMP,
+				" . $db->quoteIdentifier('time') . " timestamp DEFAULT CURRENT_TIMESTAMP,
+				" . $db->quoteIdentifier('expire_time') . " timestamp DEFAULT CURRENT_TIMESTAMP,
 				" . $db->quoteIdentifier('timed') . " int DEFAULT '0',
 				" . $db->quoteIdentifier('category_ids') . " VARCHAR(2000),
 				CONSTRAINT " . $db->quoteIdentifier('id5') . " UNIQUE ( " . $db->quoteIdentifier('id') . " )
@@ -250,9 +250,9 @@ if ($_POST["action"] == "install"){
 				" . $db->quoteIdentifier('condition') .
 				" varchar(32) default '==',
 				" . $db->quoteIdentifier('value') . " varchar( 255 ) default '',
-				" . $db->quoteIdentifier('modified') . " timestamp ,
-				" . $db->quoteIdentifier('time') . " timestamp ,
-				" . $db->quoteIdentifier('expire_time') . " timestamp ,
+				" . $db->quoteIdentifier('modified') . " timestamp DEFAULT CURRENT_TIMESTAMP,
+				" . $db->quoteIdentifier('time') . " timestamp DEFAULT CURRENT_TIMESTAMP,
+				" . $db->quoteIdentifier('expire_time') . " timestamp DEFAULT CURRENT_TIMESTAMP,
 				" . $db->quoteIdentifier('timed') . " int DEFAULT '0',
 				" . $db->quoteIdentifier('category_ids') . " text,
 				CONSTRAINT " . $db->quoteIdentifier('id5') . " UNIQUE ( " . $db->quoteIdentifier('id') . " )


### PR DESCRIPTION
Even this tool is not up to date and safe to use in public internet, it is still usable locally for personal use. However the new MySQL needs default values for timestamp fields. This patch fixes that.